### PR TITLE
Fix import paths for utils

### DIFF
--- a/Super-resolution-new/src/utils/loss.py
+++ b/Super-resolution-new/src/utils/loss.py
@@ -1,0 +1,12 @@
+
+"""Compatibility layer for legacy imports.
+
+This module re-exports the loss functions defined in :mod:`src.loss` so that
+existing code that imports from ``src.utils.loss`` continues to work even
+after the refactor that moved these utilities to the top-level ``src``
+package.
+"""
+
+from src.loss import charbonnier_loss, l1_loss
+
+__all__ = ["charbonnier_loss", "l1_loss"]

--- a/Super-resolution-new/src/utils/metrics.py
+++ b/Super-resolution-new/src/utils/metrics.py
@@ -1,0 +1,11 @@
+
+"""Compatibility layer for legacy imports.
+
+The implementation of metric functions lives in :mod:`src.metrics`.  This file
+simply re-exports those functions so that older modules importing
+``src.utils.metrics`` remain functional.
+"""
+
+from src.metrics import compute_psnr, compute_ssim, compute_lpips
+
+__all__ = ["compute_psnr", "compute_ssim", "compute_lpips"]

--- a/Super-resolution-new/src/utils/viz.py
+++ b/Super-resolution-new/src/utils/viz.py
@@ -1,0 +1,10 @@
+
+"""Compatibility layer for legacy imports.
+
+The visualization helpers were moved to :mod:`src.viz`.  This module simply
+re-exports them so that imports from ``src.utils.viz`` continue to work.
+"""
+
+from src.viz import plot_sr_triplet
+
+__all__ = ["plot_sr_triplet"]


### PR DESCRIPTION
## Summary
- patch compatibility layer for legacy utils imports
- re-export loss functions, metrics and visualization helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886081e0cec8321a9f7ddcb515c0594